### PR TITLE
correct people_set documentation

### DIFF
--- a/mixpanel-as3-lib/src/com/mixpanel/Mixpanel.as
+++ b/mixpanel-as3-lib/src/com/mixpanel/Mixpanel.as
@@ -289,7 +289,7 @@ package com.mixpanel
 		 * <pre>
 		 * 		mixpanel.people_set('gender', 'm');
 		 * 
-		 * 		mixpanel.people.set({
+		 * 		mixpanel.people_set({
 		 * 			'company': 'Acme',
 		 * 			'plan': 'free'
 		 * 		});


### PR DESCRIPTION
The people_set function incorrectly uses calls the function as people.set in the example.